### PR TITLE
Remove optional fields when requesting token

### DIFF
--- a/src/main/java/com/exacttarget/fuelsdk/ETClient.java
+++ b/src/main/java/com/exacttarget/fuelsdk/ETClient.java
@@ -262,10 +262,6 @@ public class ETClient {
         JsonObject jsonObject = new JsonObject();
         jsonObject.addProperty("clientId", clientId);
         jsonObject.addProperty("clientSecret", clientSecret);
-        jsonObject.addProperty("accessType", "offline");
-        if (refreshToken != null) {
-            jsonObject.addProperty("refreshToken", refreshToken);
-        }
 
         String requestPayload = gson.toJson(jsonObject);
 


### PR DESCRIPTION
This is the possible fix for the 401 error codes when requesting the auth token. Looks like the code is sending the refreshToken from the last request. If we had multiple servers behind a load balancer fetching tokens, some of them might fail when they are using a refreshToken that is not the current valid refreshToken. 

Since the docs say these two fields are optional, the quickest fix is to remove them.
